### PR TITLE
DataReader + DataImage + test 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(hello_world
         src/mnist_loader.cpp
         src/neural_layer.cpp
         src/neural_network.cpp
+        src/constants.cpp
         test/init/hello_world.cpp)
 
 add_executable(mnistReader
@@ -29,7 +30,8 @@ add_executable(mnistReader
         src/neural_layer.cpp
         src/neural_network.cpp
         src/DigitImage.cpp
+        src/constants.cpp
         test/MNISTReader/test_reader.cpp
-        )
+        src/constants.cpp)
 
 add_subdirectory(Google_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,4 +16,18 @@ add_executable(hello_world
         src/neural_layer.cpp
         src/neural_network.cpp
         test/init/hello_world.cpp)
+
+add_executable(mnistReader
+        include/constants.h
+        include/matrix.h
+        include/mnist_loader.h
+        include/neural_layer.h
+        include/neural_network.h
+        src/matrix.cpp
+        src/mnist_loader.cpp
+        src/neural_layer.cpp
+        src/neural_network.cpp
+        test/MNISTReader/test_reader.cpp
+        )
+
 add_subdirectory(Google_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,12 @@ add_executable(mnistReader
         include/mnist_loader.h
         include/neural_layer.h
         include/neural_network.h
+        include/DigitImage.h
         src/matrix.cpp
         src/mnist_loader.cpp
         src/neural_layer.cpp
         src/neural_network.cpp
-        include/DigitImage.h
+        src/DigitImage.cpp
         test/MNISTReader/test_reader.cpp
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(mnistReader
         src/mnist_loader.cpp
         src/neural_layer.cpp
         src/neural_network.cpp
+        include/DigitImage.h
         test/MNISTReader/test_reader.cpp
         )
 

--- a/include/DigitImage.h
+++ b/include/DigitImage.h
@@ -1,0 +1,61 @@
+//
+// Created by razor on 20/05/2023.
+//
+
+#include <vector>
+#include <iostream>
+#include <iomanip>
+
+#ifndef PROYECTO_FINAL_TE02_202301_PF0220231_GRUPO1_SUB_1_DIGITIMAGE_H
+#define PROYECTO_FINAL_TE02_202301_PF0220231_GRUPO1_SUB_1_DIGITIMAGE_H
+
+class DigitImage {
+public:
+    using vPixels= std::vector<float>;
+    //Constructors
+    DigitImage()=default;
+    DigitImage(int _w, int _h, unsigned int _l, vPixels pixels): width(_w), height(_h), label(_l), image(std::move(pixels)){}
+    DigitImage(const DigitImage& other) : width(other.width), height(other.height), label(other.label), image(other.image) {}
+    DigitImage(DigitImage&& other) noexcept : width(other.width), height(other.height), label(other.label), image(std::move(other.image)) {
+        other.width = 0;
+        other.height = 0;
+        other.label = 0;
+    }
+
+
+    //Desctructors
+    virtual ~DigitImage()=default;
+
+    //Getters
+    unsigned int get_width(){return width;}
+    unsigned int get_height(){return height;}
+    unsigned int get_label(){return label;}
+    vPixels get_image(){return image;}
+
+    //Setters
+    void set_image(vPixels px){image = std::move(px);}
+    void set_label(unsigned int _l){label = _l;}
+
+    //Operators Overloads
+    friend std::ostream& operator << (std::ostream& o, const DigitImage& img ){
+        std::cout <<"\nMatriz de pixeles del numero : " << img.label << '\n';
+
+        for(int i = 0; i < img.height; i++){
+            for(int j = 0; j < img.width; j++){
+                std::string ch = img.image[i * img.width + j] != 0 ? "0" : "&&";
+                std::cout << ch << std::setw(4);
+            }
+            std::cout << '\n';
+        }
+        return o;
+    }
+
+private:
+    unsigned int width = 0;
+    unsigned int height = 0;
+    unsigned int label = 10;
+    vPixels image;
+};
+
+
+#endif //PROYECTO_FINAL_TE02_202301_PF0220231_GRUPO1_SUB_1_DIGITIMAGE_H

--- a/include/DigitImage.h
+++ b/include/DigitImage.h
@@ -1,7 +1,3 @@
-//
-// Created by razor on 20/05/2023.
-//
-
 #include <vector>
 #include <iostream>
 #include <iomanip>

--- a/include/constants.h
+++ b/include/constants.h
@@ -1,4 +1,7 @@
 #ifndef MNISTPLUSPLUS_CONSTANTS_H
 #define MNISTPLUSPLUS_CONSTANTS_H
 
+
+enum read{mn_label = 2049 , mn_img = 2051, test_num=10000,train_num = 60000};
+
 #endif //MNISTPLUSPLUS_CONSTANTS_H

--- a/include/constants.h
+++ b/include/constants.h
@@ -5,4 +5,7 @@
 enum read{MN_LABEL = 2049 , MN_IMG = 2051, TEST_NUM=10000,TRAIN_NUM = 60000};
 
 extern std::string TRAIN_IMAGE_PATH;
+extern std::string TRAIN_LABEL_PATH;
+extern std::string TEST_IMAGE_PATH;
+extern std::string TEST_LABEL_PATH;
 #endif //MNISTPLUSPLUS_CONSTANTS_H

--- a/include/constants.h
+++ b/include/constants.h
@@ -1,7 +1,8 @@
 #ifndef MNISTPLUSPLUS_CONSTANTS_H
 #define MNISTPLUSPLUS_CONSTANTS_H
 
+#include <string>
+enum read{MN_LABEL = 2049 , MN_IMG = 2051, TEST_NUM=10000,TRAIN_NUM = 60000};
 
-enum read{mn_label = 2049 , mn_img = 2051, test_num=10000,train_num = 60000};
-
+extern std::string TRAIN_IMAGE_PATH;
 #endif //MNISTPLUSPLUS_CONSTANTS_H

--- a/include/mnist_loader.h
+++ b/include/mnist_loader.h
@@ -4,6 +4,7 @@
 #include <bit>
 #include <iostream>
 #include <fstream>
+#include "constants.h"
 
 #ifndef MNISTPLUSPLUS_MNIST_LOADER_H
 #define MNISTPLUSPLUS_MNIST_LOADER_H
@@ -15,112 +16,107 @@ public:
 
     MNISTReader()=default;
 
-    void loadTrainDataset(const std::string& imgPath, const std::string& labelPath) {
+    void loadTrainDataset(const std::string& img_path, const std::string& label_path) {
 
-        std::ifstream imagesFile(imgPath, std::ios::binary);
-        std::ifstream labelsFile(labelPath, std::ios::binary);
+        std::ifstream images_file(img_path, std::ios::binary);
+        std::ifstream labelsFile(label_path, std::ios::binary);
 
-        if (imagesFile.is_open() && labelsFile.is_open()) {
-            int magicNum, numRows, numCols, numImage = 60000;
+        if (images_file.is_open() && labelsFile.is_open()) {
+            #include "constants.h"
+            int magic_num, num_rows, num_cols, num_image = read::train_num;
 
-            imagesFile.read(reinterpret_cast<char *>(&magicNum), sizeof(magicNum));
-            imagesFile.read(reinterpret_cast<char *>(&numImage), sizeof(numImage));
-            imagesFile.read(reinterpret_cast<char *>(&numRows), sizeof(numRows));
-            imagesFile.read(reinterpret_cast<char *>(&numCols), sizeof(numCols));
-
-
-            magicNum = __builtin_bswap32(magicNum);
-            numImage = __builtin_bswap32(numImage);
-            numRows = __builtin_bswap32(numRows);
-            numCols = __builtin_bswap32(numCols);
+            images_file.read(reinterpret_cast<char *>(&magic_num), sizeof(magic_num));
+            images_file.read(reinterpret_cast<char *>(&num_image), sizeof(num_image));
+            images_file.read(reinterpret_cast<char *>(&num_rows), sizeof(num_rows));
+            images_file.read(reinterpret_cast<char *>(&num_cols), sizeof(num_cols));
 
 
-            if (magicNum != 2051) throw std::invalid_argument("Magic number mismatch, expected 2051");
+            magic_num = __builtin_bswap32(magic_num);
+            num_image = __builtin_bswap32(num_image);
+            num_rows = __builtin_bswap32(num_rows);
+            num_cols = __builtin_bswap32(num_cols);
 
-            int labelMagicNumber, numLabels;
-            labelsFile.read(reinterpret_cast<char *>(&labelMagicNumber), sizeof(labelMagicNumber));
-            labelsFile.read(reinterpret_cast<char *>(&numLabels), sizeof(numLabels));
 
-            labelMagicNumber = __builtin_bswap32(labelMagicNumber);
-            numLabels = __builtin_bswap32(numLabels);
-            if (labelMagicNumber != 2049) throw std::invalid_argument("Magic number mismatch, expected 2049");
+            if (magic_num !=read::mn_img) throw std::invalid_argument("Magic number mismatch, expected 2051");
 
-            for (int i = 0; i < numImage; ++i) {
-                std::vector<float> img(numRows * numCols);
+            int label_magic_number, num_labels;
+            labelsFile.read(reinterpret_cast<char *>(&label_magic_number), sizeof(label_magic_number));
+            labelsFile.read(reinterpret_cast<char *>(&num_labels), sizeof(num_labels));
 
-                for (int pixel = 0; pixel < numRows * numCols; ++pixel) {
-                    unsigned char pixelValue;
-                    imagesFile.read(reinterpret_cast<char *>(&pixelValue), sizeof(pixelValue));
-                    img[pixel] = static_cast<float>(pixelValue) / 255.0f;
+            label_magic_number = __builtin_bswap32(label_magic_number);
+            num_labels = __builtin_bswap32(num_labels);
+            if (label_magic_number != read::mn_label) throw std::invalid_argument("Magic number mismatch, expected 2049");
+
+            for (int i = 0; i < num_image; ++i) {
+                std::vector<float> img(num_rows * num_cols);
+
+                for (int pixel = 0; pixel < num_rows * num_cols; ++pixel) {
+                    unsigned char pixel_value;
+                    images_file.read(reinterpret_cast<char *>(&pixel_value), sizeof(pixel_value));
+                    img[pixel] = static_cast<float>(pixel_value) / 255.0f;
                 }
 
                 unsigned char label;
                 labelsFile.read(reinterpret_cast<char *>(&label), sizeof(label));
-                DigitImage new_img(numRows, numCols, label, img);
-                trainImages.push_back(new_img);
+                DigitImage new_img(num_rows, num_cols, label, img);
+                train_images.push_back(new_img);
             }
-            imagesFile.close();
+            images_file.close();
             labelsFile.close();
         }else throw std::runtime_error("Invalid files or filepaths");
     }
 
-    void loadTestDataset(const std::string& imgPath, const std::string& labelPath){
-        std::ifstream imagesFile(imgPath, std::ios::binary);
-        std::ifstream labelsFile(labelPath, std::ios::binary);
+    void loadTestDataset(const std::string& img_path, const std::string& label_path){
+        std::ifstream images_file(img_path, std::ios::binary);
+        std::ifstream labels_file(label_path, std::ios::binary);
 
-        if (imagesFile.is_open() && labelsFile.is_open()) {
-            int magicNum, numRows, numCols, numImage = 10000;
+        if (images_file.is_open() && labels_file.is_open()) {
+            int magic_num, num_rows, num_cols, num_image = read::train_num;
 
-            imagesFile.read(reinterpret_cast<char *>(&magicNum), sizeof(magicNum));
-            imagesFile.read(reinterpret_cast<char *>(&numImage), sizeof(numImage));
-            imagesFile.read(reinterpret_cast<char *>(&numRows), sizeof(numRows));
-            imagesFile.read(reinterpret_cast<char *>(&numCols), sizeof(numCols));
+            images_file.read(reinterpret_cast<char *>(&magic_num), sizeof(magic_num));
+            images_file.read(reinterpret_cast<char *>(&num_image), sizeof(num_image));
+            images_file.read(reinterpret_cast<char *>(&num_rows), sizeof(num_rows));
+            images_file.read(reinterpret_cast<char *>(&num_cols), sizeof(num_cols));
 
-            magicNum = __builtin_bswap32(magicNum);
-            numImage = __builtin_bswap32(numImage);
-            numRows = __builtin_bswap32(numRows);
-            numCols = __builtin_bswap32(numCols);
+            magic_num = __builtin_bswap32(magic_num);
+            num_image = __builtin_bswap32(num_image);
+            num_rows = __builtin_bswap32(num_rows);
+            num_cols = __builtin_bswap32(num_cols);
 
 
-            if (magicNum != 2051) throw std::invalid_argument("Test images magic number mismatch, expected 2051");
+            if (magic_num != read::mn_img) throw std::invalid_argument("Test images magic number mismatch, expected 2051");
 
-            int labelMagicNumber, numLabels;
-            labelsFile.read(reinterpret_cast<char *>(&labelMagicNumber), sizeof(labelMagicNumber));
-            labelsFile.read(reinterpret_cast<char *>(&numLabels), sizeof(numLabels));
+            int label_magic_number, num_labels;
+            labels_file.read(reinterpret_cast<char *>(&label_magic_number), sizeof(label_magic_number));
+            labels_file.read(reinterpret_cast<char *>(&num_labels), sizeof(num_labels));
 
-            labelMagicNumber = __builtin_bswap32(labelMagicNumber);
-            numLabels = __builtin_bswap32(numLabels);
+            label_magic_number = __builtin_bswap32(label_magic_number);
+            num_labels = __builtin_bswap32(num_labels);
 
-            if (labelMagicNumber != 2049) throw std::invalid_argument("Test labels  magic number mismatch, expected 2049");
-            for (int i = 0; i < numImage; ++i) {
-                std::vector<float> img(numRows * numCols);
+            if (label_magic_number != read::mn_label) throw std::invalid_argument("Test labels  magic number mismatch, expected 2049");
+            for (int i = 0; i < num_image; ++i) {
+                std::vector<float> img(num_rows * num_cols);
 
-                for (int pixel = 0; pixel < numRows * numCols; ++pixel) {
-                    unsigned char pixelValue;
-                    imagesFile.read(reinterpret_cast<char *>(&pixelValue), sizeof(pixelValue));
-                    img[pixel] = static_cast<float>(pixelValue) / 255.0f;
+                for (int pixel = 0; pixel < num_rows * num_cols; ++pixel) {
+                    unsigned char pixel_value;
+                    images_file.read(reinterpret_cast<char *>(&pixel_value), sizeof(pixel_value));
+                    img[pixel] = static_cast<float>(pixel_value) / 255.0f;
                 }
 
                 unsigned char label;
-                labelsFile.read(reinterpret_cast<char *>(&label), sizeof(label));
-                DigitImage new_img(numRows, numCols, label, img);
-                testImages.push_back(new_img);
+                labels_file.read(reinterpret_cast<char *>(&label), sizeof(label));
+                DigitImage new_img(num_rows, num_cols, label, img);
+                test_images.push_back(new_img);
             }
         }
     }
 
-    v_images getTrainImg() const {return trainImages;}
-    v_images getTestImg()  const {return testImages;}
+    v_images getTrainImg() const {return train_images;}
+    v_images getTestImg()  const {return test_images;}
 
-
-    /*friend std::ostream& operator<<(std::ostream& o, const MNISTReader& reader){
-        for(int i = 0; i <5 ; i++){
-            std::cout << reader.trainImages[i];
-        }
-    }*/
 private:
-    v_images trainImages ;
-    v_images testImages;
+    v_images train_images ;
+    v_images test_images;
 };
 
 

--- a/include/mnist_loader.h
+++ b/include/mnist_loader.h
@@ -1,9 +1,126 @@
+#include "DigitImage.h"
+#include <vector>
+#include <string>
+#include <bit>
+#include <iostream>
+#include <fstream>
+
 #ifndef MNISTPLUSPLUS_MNIST_LOADER_H
 #define MNISTPLUSPLUS_MNIST_LOADER_H
 
 
-class mnist_loader {
+class MNISTReader {
+public:
+    using v_images = std::vector<DigitImage> ;
 
+    MNISTReader()=default;
+
+    void loadTrainDataset(const std::string& imgPath, const std::string& labelPath) {
+
+        std::ifstream imagesFile(imgPath, std::ios::binary);
+        std::ifstream labelsFile(labelPath, std::ios::binary);
+
+        if (imagesFile.is_open() && labelsFile.is_open()) {
+            int magicNum, numRows, numCols, numImage = 60000;
+
+            imagesFile.read(reinterpret_cast<char *>(&magicNum), sizeof(magicNum));
+            imagesFile.read(reinterpret_cast<char *>(&numImage), sizeof(numImage));
+            imagesFile.read(reinterpret_cast<char *>(&numRows), sizeof(numRows));
+            imagesFile.read(reinterpret_cast<char *>(&numCols), sizeof(numCols));
+
+
+            magicNum = __builtin_bswap32(magicNum);
+            numImage = __builtin_bswap32(numImage);
+            numRows = __builtin_bswap32(numRows);
+            numCols = __builtin_bswap32(numCols);
+
+
+            if (magicNum != 2051) throw std::invalid_argument("Magic number mismatch, expected 2051");
+
+            int labelMagicNumber, numLabels;
+            labelsFile.read(reinterpret_cast<char *>(&labelMagicNumber), sizeof(labelMagicNumber));
+            labelsFile.read(reinterpret_cast<char *>(&numLabels), sizeof(numLabels));
+
+            labelMagicNumber = __builtin_bswap32(labelMagicNumber);
+            numLabels = __builtin_bswap32(numLabels);
+            if (labelMagicNumber != 2049) throw std::invalid_argument("Magic number mismatch, expected 2049");
+
+            for (int i = 0; i < numImage; ++i) {
+                std::vector<float> img(numRows * numCols);
+
+                for (int pixel = 0; pixel < numRows * numCols; ++pixel) {
+                    unsigned char pixelValue;
+                    imagesFile.read(reinterpret_cast<char *>(&pixelValue), sizeof(pixelValue));
+                    img[pixel] = static_cast<float>(pixelValue) / 255.0f;
+                }
+
+                unsigned char label;
+                labelsFile.read(reinterpret_cast<char *>(&label), sizeof(label));
+                DigitImage new_img(numRows, numCols, label, img);
+                trainImages.push_back(new_img);
+            }
+            imagesFile.close();
+            labelsFile.close();
+        }else throw std::runtime_error("Invalid files or filepaths");
+    }
+
+    void loadTestDataset(const std::string& imgPath, const std::string& labelPath){
+        std::ifstream imagesFile(imgPath, std::ios::binary);
+        std::ifstream labelsFile(labelPath, std::ios::binary);
+
+        if (imagesFile.is_open() && labelsFile.is_open()) {
+            int magicNum, numRows, numCols, numImage = 10000;
+
+            imagesFile.read(reinterpret_cast<char *>(&magicNum), sizeof(magicNum));
+            imagesFile.read(reinterpret_cast<char *>(&numImage), sizeof(numImage));
+            imagesFile.read(reinterpret_cast<char *>(&numRows), sizeof(numRows));
+            imagesFile.read(reinterpret_cast<char *>(&numCols), sizeof(numCols));
+
+            magicNum = __builtin_bswap32(magicNum);
+            numImage = __builtin_bswap32(numImage);
+            numRows = __builtin_bswap32(numRows);
+            numCols = __builtin_bswap32(numCols);
+
+
+            if (magicNum != 2051) throw std::invalid_argument("Test images magic number mismatch, expected 2051");
+
+            int labelMagicNumber, numLabels;
+            labelsFile.read(reinterpret_cast<char *>(&labelMagicNumber), sizeof(labelMagicNumber));
+            labelsFile.read(reinterpret_cast<char *>(&numLabels), sizeof(numLabels));
+
+            labelMagicNumber = __builtin_bswap32(labelMagicNumber);
+            numLabels = __builtin_bswap32(numLabels);
+
+            if (labelMagicNumber != 2049) throw std::invalid_argument("Test labels  magic number mismatch, expected 2049");
+            for (int i = 0; i < numImage; ++i) {
+                std::vector<float> img(numRows * numCols);
+
+                for (int pixel = 0; pixel < numRows * numCols; ++pixel) {
+                    unsigned char pixelValue;
+                    imagesFile.read(reinterpret_cast<char *>(&pixelValue), sizeof(pixelValue));
+                    img[pixel] = static_cast<float>(pixelValue) / 255.0f;
+                }
+
+                unsigned char label;
+                labelsFile.read(reinterpret_cast<char *>(&label), sizeof(label));
+                DigitImage new_img(numRows, numCols, label, img);
+                testImages.push_back(new_img);
+            }
+        }
+    }
+
+    v_images getTrainImg() const {return trainImages;}
+    v_images getTestImg()  const {return testImages;}
+
+
+    /*friend std::ostream& operator<<(std::ostream& o, const MNISTReader& reader){
+        for(int i = 0; i <5 ; i++){
+            std::cout << reader.trainImages[i];
+        }
+    }*/
+private:
+    v_images trainImages ;
+    v_images testImages;
 };
 
 

--- a/include/mnist_loader.h
+++ b/include/mnist_loader.h
@@ -9,7 +9,6 @@
 #ifndef MNISTPLUSPLUS_MNIST_LOADER_H
 #define MNISTPLUSPLUS_MNIST_LOADER_H
 
-
 class MNISTReader {
 public:
     using v_images = std::vector<DigitImage> ;
@@ -23,7 +22,7 @@ public:
 
         if (images_file.is_open() && labelsFile.is_open()) {
             #include "constants.h"
-            int magic_num, num_rows, num_cols, num_image = read::train_num;
+            int magic_num, num_rows, num_cols, num_image = read::TRAIN_NUM;
 
             images_file.read(reinterpret_cast<char *>(&magic_num), sizeof(magic_num));
             images_file.read(reinterpret_cast<char *>(&num_image), sizeof(num_image));
@@ -37,7 +36,7 @@ public:
             num_cols = __builtin_bswap32(num_cols);
 
 
-            if (magic_num !=read::mn_img) throw std::invalid_argument("Magic number mismatch, expected 2051");
+            if (magic_num !=read::MN_IMG) throw std::invalid_argument("Magic number mismatch, expected 2051");
 
             int label_magic_number, num_labels;
             labelsFile.read(reinterpret_cast<char *>(&label_magic_number), sizeof(label_magic_number));
@@ -45,7 +44,7 @@ public:
 
             label_magic_number = __builtin_bswap32(label_magic_number);
             num_labels = __builtin_bswap32(num_labels);
-            if (label_magic_number != read::mn_label) throw std::invalid_argument("Magic number mismatch, expected 2049");
+            if (label_magic_number != read::MN_LABEL) throw std::invalid_argument("Magic number mismatch, expected 2049");
 
             for (int i = 0; i < num_image; ++i) {
                 std::vector<float> img(num_rows * num_cols);
@@ -71,7 +70,7 @@ public:
         std::ifstream labels_file(label_path, std::ios::binary);
 
         if (images_file.is_open() && labels_file.is_open()) {
-            int magic_num, num_rows, num_cols, num_image = read::train_num;
+            int magic_num, num_rows, num_cols, num_image = read::TRAIN_NUM;
 
             images_file.read(reinterpret_cast<char *>(&magic_num), sizeof(magic_num));
             images_file.read(reinterpret_cast<char *>(&num_image), sizeof(num_image));
@@ -84,7 +83,7 @@ public:
             num_cols = __builtin_bswap32(num_cols);
 
 
-            if (magic_num != read::mn_img) throw std::invalid_argument("Test images magic number mismatch, expected 2051");
+            if (magic_num != read::MN_IMG) throw std::invalid_argument("Test images magic number mismatch, expected 2051");
 
             int label_magic_number, num_labels;
             labels_file.read(reinterpret_cast<char *>(&label_magic_number), sizeof(label_magic_number));
@@ -93,7 +92,7 @@ public:
             label_magic_number = __builtin_bswap32(label_magic_number);
             num_labels = __builtin_bswap32(num_labels);
 
-            if (label_magic_number != read::mn_label) throw std::invalid_argument("Test labels  magic number mismatch, expected 2049");
+            if (label_magic_number != read::MN_LABEL) throw std::invalid_argument("Test labels  magic number mismatch, expected 2049");
             for (int i = 0; i < num_image; ++i) {
                 std::vector<float> img(num_rows * num_cols);
 

--- a/src/DigitImage.cpp
+++ b/src/DigitImage.cpp
@@ -1,0 +1,3 @@
+//
+// Created by razor on 20/05/2023.
+//

--- a/src/DigitImage.cpp
+++ b/src/DigitImage.cpp
@@ -1,3 +1,0 @@
-//
-// Created by razor on 20/05/2023.
-//

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -1,0 +1,3 @@
+#include "constants.h"
+
+std::string TRAIN_IMAGE_PATH = "../data/train-images.idx3-ubyte";

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -1,3 +1,6 @@
 #include "constants.h"
 
 std::string TRAIN_IMAGE_PATH = "../data/train-images.idx3-ubyte";
+std::string TRAIN_LABEL_PATH = "../Data/train-labels.idx1-ubyte";
+std::string TEST_IMAGE_PATH = "../data/t10k-images.idx3-ubyte";
+std::string TEST_LABEL_PATH = "../Data/t10k-labels.idx1-ubyte";

--- a/test/MNISTReader/test_reader.cpp
+++ b/test/MNISTReader/test_reader.cpp
@@ -14,13 +14,13 @@ int main() {
 
     std::cout << "\nLoad train images test\n";
     for(int i = 0; i<10 ; ++i){
-        int idx = rand()%read::train_num +1;
+        int idx = rand()%read::TRAIN_NUM + 1;
         std::cout << trainImages[idx];
     }
 
     std::cout << "\nLoad test images test\n";
     for(int i = 0; i<10 ; ++i){
-        int idx = rand()%read::test_num+1;
+        int idx = rand()%read::TEST_NUM + 1;
         std::cout << testImages[idx];
     }
     return 0;

--- a/test/MNISTReader/test_reader.cpp
+++ b/test/MNISTReader/test_reader.cpp
@@ -1,4 +1,5 @@
 #include "../../include/mnist_loader.h"
+#include "constants.h"
 #include <iostream>
 #include <time.h>
 
@@ -6,8 +7,8 @@ int main() {
     srand(time(0));
 
     MNISTReader dataset;
-    dataset.loadTrainDataset("../data/train-images.idx3-ubyte","../Data/train-labels.idx1-ubyte" );
-    dataset.loadTestDataset("../data/t10k-images.idx3-ubyte","../Data/t10k-labels.idx1-ubyte" );
+    dataset.loadTrainDataset(TRAIN_IMAGE_PATH, TRAIN_LABEL_PATH);
+    dataset.loadTestDataset(TEST_IMAGE_PATH,TEST_LABEL_PATH);
 
     auto trainImages = dataset.getTrainImg();
     auto testImages = dataset.getTestImg();

--- a/test/MNISTReader/test_reader.cpp
+++ b/test/MNISTReader/test_reader.cpp
@@ -1,0 +1,28 @@
+
+#include "../../include/mnist_loader.h"
+#include <iostream>
+#include <time.h>
+
+int main() {
+    srand(time(0));
+
+    MNISTReader dataset;
+    dataset.loadTrainDataset("../data/train-images.idx3-ubyte","../Data/train-labels.idx1-ubyte" );
+    dataset.loadTestDataset("../data/t10k-images.idx3-ubyte","../Data/t10k-labels.idx1-ubyte" );
+
+    auto trainImages = dataset.getTrainImg();
+    auto testImages = dataset.getTestImg();
+
+    std::cout << "\nLoad train images test\n";
+    for(int i = 0; i<10 ; ++i){
+        int idx = rand()%60000 +1;
+        std::cout << trainImages[idx];
+    }
+
+    std::cout << "\nLoad test images test\n";
+    for(int i = 0; i<10 ; ++i){
+        int idx = rand()%10+1;
+        std::cout << testImages[idx];
+    }
+    return 0;
+}

--- a/test/MNISTReader/test_reader.cpp
+++ b/test/MNISTReader/test_reader.cpp
@@ -1,4 +1,3 @@
-
 #include "../../include/mnist_loader.h"
 #include <iostream>
 #include <time.h>
@@ -15,13 +14,13 @@ int main() {
 
     std::cout << "\nLoad train images test\n";
     for(int i = 0; i<10 ; ++i){
-        int idx = rand()%60000 +1;
+        int idx = rand()%read::train_num +1;
         std::cout << trainImages[idx];
     }
 
     std::cout << "\nLoad test images test\n";
     for(int i = 0; i<10 ; ++i){
-        int idx = rand()%10+1;
+        int idx = rand()%read::test_num+1;
         std::cout << testImages[idx];
     }
     return 0;


### PR DESCRIPTION
Implementación de la clase MNISTDataReader con los metodos:
* loadTrainDataset: Lee los 60000 datos del dataset de entrenamiento ( images + labes ) y los almacena  en un vector de objeto DataImage
* loadTestDataset: Lee los 10000 datos del dataset de test ( images + labes ) y los almacena en un vector de objeto DataImage

